### PR TITLE
updated EO version to 0.29.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
-      <version>0.29.0</version>
+      <version>0.29.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -110,7 +110,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.29.0</version>
+        <version>0.29.4</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/src/main/eo/org/eolang/fs/dir.eo
+++ b/src/main/eo/org/eolang/fs/dir.eo
@@ -37,7 +37,7 @@
 
   # Go though all files in the directory, recursively
   # finding them with the "glob" provided.
-  [glob] > walk /array
+  [glob] > walk /tuple
 
   # Delete directory and all files in it, recursively.
   # Always returns TRUE.

--- a/src/main/eo/org/eolang/io/bytes-as-input.eo
+++ b/src/main/eo/org/eolang/io/bytes-as-input.eo
@@ -29,7 +29,6 @@
 # need to specify the last two arguments, only the first
 # one: the bytes to read.
 [b next buf] > bytes-as-input
-
   buf > @
 
   # Read the next chunk of bytes and

--- a/src/main/eo/org/eolang/io/memory-as-output.eo
+++ b/src/main/eo/org/eolang/io/memory-as-output.eo
@@ -27,7 +27,6 @@
 
 # Turns memory into an output.
 [m] > memory-as-output
-
   m > @
 
   # Write the next chunk of bytes and


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the eo-runtime and eo-maven-plugin dependencies, and makes some minor changes to code in three files. 

### Detailed summary
- Updated eo-runtime and eo-maven-plugin dependencies to version 0.29.4
- Changed the return type of `walk` function in `dir.eo` from `/array` to `/tuple`
- Minor changes to `memory-as-output.eo` and `bytes-as-input.eo` files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->