### PR TITLE
#90: Replaced int with String

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,13 +90,13 @@ SOFTWARE.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.2</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.9.2</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/EOorg/EOeolang/EOfs/EOfileEOas_inputTest.java
+++ b/src/test/java/EOorg/EOeolang/EOfs/EOfileEOas_inputTest.java
@@ -59,7 +59,7 @@ public final class EOfileEOas_inputTest {
 
     @ParameterizedTest
     @CsvFileSource(resources = "/EOlang/EOio/test-samples.csv")
-    public void readsBytes(final String text, final int max) throws IOException {
+    public void readsBytes(final String text, final String max) throws IOException {
         final Path file = this.temp.resolve("test.txt");
         Files.write(file, text.getBytes(StandardCharsets.UTF_8));
         Phi input = new PhWith(
@@ -79,7 +79,7 @@ public final class EOfileEOas_inputTest {
                 new PhMethod(
                     new PhWith(
                         input.attr("read").get(),
-                        "max", new Data.ToPhi((long) max)
+                        "max", new Data.ToPhi(Long.parseLong(max))
                     ),
                     "φ"
                 )

--- a/src/test/java/EOorg/EOeolang/EOfs/EOfileEOas_outputTest.java
+++ b/src/test/java/EOorg/EOeolang/EOfs/EOfileEOas_outputTest.java
@@ -58,7 +58,7 @@ public final class EOfileEOas_outputTest {
 
     @ParameterizedTest
     @CsvFileSource(resources = "/EOlang/EOio/test-samples.csv")
-    public void writesBytesToFile(final String text, final int max) throws IOException {
+    public void writesBytesToFile(final String text, final String max) throws IOException {
         final Path file = this.temp.resolve("test.txt");
         Phi output = new PhWith(
             new PhMethod(
@@ -75,7 +75,7 @@ public final class EOfileEOas_outputTest {
         int pos = 0;
         while (true) {
             final byte[] chunk = Arrays.copyOfRange(
-                bytes, pos, Integer.min(pos + max, bytes.length)
+                bytes, pos, Integer.min(pos + Integer.parseInt(max), bytes.length)
             );
             output = new PhConst(
                 new PhMethod(

--- a/src/test/java/EOorg/EOeolang/EOio/EObytes_as_inputEOreadTest.java
+++ b/src/test/java/EOorg/EOeolang/EOio/EObytes_as_inputEOreadTest.java
@@ -49,7 +49,7 @@ public final class EObytes_as_inputEOreadTest {
 
     @ParameterizedTest
     @CsvFileSource(resources = "/EOlang/EOio/test-samples.csv")
-    public void readsBytes(final String text, final int max) throws IOException {
+    public void readsBytes(final String text, final String max) throws IOException {
         final Phi bytes = new Data.ToPhi(text.getBytes(StandardCharsets.UTF_8));
         Phi input = new PhWith(
             new EObytes_as_input(bytes),
@@ -60,7 +60,7 @@ public final class EObytes_as_inputEOreadTest {
             input = new PhConst(
                 new PhWith(
                     input.attr("read").get(),
-                    "max", new Data.ToPhi((long) max)
+                    "max", new Data.ToPhi(Long.parseLong(max))
                 )
             );
             final byte[] chunk = new Dataized(input).take(byte[].class);
@@ -78,7 +78,7 @@ public final class EObytes_as_inputEOreadTest {
 
     @ParameterizedTest
     @CsvFileSource(resources = "/EOlang/EOio/test-samples.csv")
-    public void readsBytesFromString(final String text, final int max) {
+    public void readsBytesFromString(final String text, final String max) {
         final Phi input = new PhWith(
             new EObytes_as_input(Phi.Φ),
             "b",
@@ -90,13 +90,13 @@ public final class EObytes_as_inputEOreadTest {
         final Phi first = new PhConst(
             new PhWith(
                 input.attr("read").get(),
-                "max", new Data.ToPhi((long) max)
+                "max", new Data.ToPhi(Long.parseLong(max))
             )
         );
         final Phi last = new PhConst(
             new PhWith(
                 first.attr("read").get(),
-                "max", new Data.ToPhi((long) max)
+                "max", new Data.ToPhi(Long.parseLong(max))
             )
         ).copy();
         Assertions.assertDoesNotThrow(


### PR DESCRIPTION
Closes #90 
I don't know why it cannot to converse `String` to `int` implicitly like it was in previous version. I guess its just a bug

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of JUnit Jupiter API and JUnit Jupiter Params dependencies. It also modifies method parameters from int to String in three test classes.

### Detailed summary
- Updated JUnit Jupiter API version from 5.9.2 to 5.10.1 in pom.xml.
- Updated JUnit Jupiter Params version from 5.9.2 to 5.10.1 in pom.xml.
- Changed method parameter types from int to String in `EOfileEOas_inputTest.java`, `EOfileEOas_outputTest.java`, and `EObytes_as_inputEOreadTest.java` test classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->